### PR TITLE
fix: _scroll_to carsh

### DIFF
--- a/src/vt.tsx
+++ b/src/vt.tsx
@@ -299,6 +299,7 @@ function update_wrap_style(ctx: VT_CONTEXT, h: number): void {
 
 // scrolls the parent element to specified location.
 function _scroll_to(ctx: VT_CONTEXT, top: number, left: number): void {
+  if (!ctx.wrap_inst.current) return;
   const ele = ctx.wrap_inst.current.parentElement;
   /** ie */
   ele.scrollTop = top;


### PR DESCRIPTION
当执行`_scroll_to`方法时, 会因为`ctx.wrap_inst.current`为`null`导致崩溃, 我没找到一个可以防止这个错误的配置, 麻烦看看这个PR是否合适