### PR TITLE
修复 fixed=”right“ 时 和 主table 有一个17px的滚动条宽度的空白缝隙

### DIFF
--- a/src/vt.tsx
+++ b/src/vt.tsx
@@ -971,7 +971,7 @@ class VTable extends React.Component<VTProps> {
     const { _offset_top } = ctx;
 
     const { style, children, ...rest } = this.props;
-    style.position = "absolute";
+    style.position = "relative";
     style.top = _offset_top;
     const { width, ...rest_style } = style;
 


### PR DESCRIPTION
close #41 