### PR TITLE
change getBoundingClientRect from offsetwidth

### DIFF
--- a/src/vt.tsx
+++ b/src/vt.tsx
@@ -721,7 +721,7 @@ function VTRow<T>(props: VRowProps<T>) {
 
 
   useEffect(() => {
-    const h = inst.current.offsetHeight;
+    const h = Math.ceil(inst.current.getBoundingClientRect().height); // change from fb9f71f
     const curr_h = ctx.row_height[index];
     const last_h = ctx.row_height[last_index.current];
 


### PR DESCRIPTION
"offsetwidth" is round the value to an intege. So I want you to use "getBoundingClientRect".

https://developer.mozilla.org/ja/docs/Web/API/Element/getBoundingClientRect

The same thing happens with the issue below in the scroll view.
https://github.com/ant-design/ant-design/issues/25300#issuecomment-652980264

