### PR TITLE
Bug fixes

### DIFF
--- a/src/vt.tsx
+++ b/src/vt.tsx
@@ -576,6 +576,14 @@ function VTable(props: VTableProps, ref: React.Ref<vt_opts['ref']['current']>) {
     force[1](++ctx.update_count);
   }, []);
 
+  useEffect(() => {
+    // on scroll size change rerender
+    scroll_hook({
+      target: { scrollTop: ctx.top, scrollLeft: ctx.left },
+      flag: SCROLLEVT_BY_HOOK,
+    });
+  }, [ctx.scroll.y])
+
 
   // expose to the parent components you are using.
   useImperativeHandle(ref, () => {


### PR DESCRIPTION
This PR fixes three bugs

- **Fix issue with expandable rows**
Codesandbox link (with the issue): https://codesandbox.io/s/compassionate-microservice-olu3e
**Problem:** Antd tree doesn't flatten up the nested data in component hierarchy but flattens it on DOM hierarchy. This breaks the virtual scroll algorithm which considers only the parent level row. 
To fix this we virtually combine the nested doms, by including the height of nested row on parent row. So they are treated as one element using row_height.

- **Rerender if scroll.y changes.**

- **Fix calculation for finding bottom limit of row for rendering**
**Problem**: It looks like the logic for finding the bottom boundary of row (j) uses the incorrect rowHeights, leading to unexpected scroll bugs when the row heights for different row are not same. The calculation should start from visible rows (in a scroll area).